### PR TITLE
Update cloudposse dependency and fix ConcurrentUpdateException

### DIFF
--- a/modules/autoscaling/main.tf
+++ b/modules/autoscaling/main.tf
@@ -1,6 +1,6 @@
 module "ecs_cloudwatch_autoscaling_cpu" {
   source  = "cloudposse/ecs-cloudwatch-autoscaling/aws"
-  version = "0.7.3"
+  version = "0.7.5"
 
   name                  = var.service_name
   attributes            = ["cpu"]
@@ -19,7 +19,7 @@ module "ecs_cloudwatch_autoscaling_cpu" {
 
 module "ecs_cloudwatch_autoscaling_memory" {
   source  = "cloudposse/ecs-cloudwatch-autoscaling/aws"
-  version = "0.7.3"
+  version = "0.7.5"
 
   name                  = var.service_name
   attributes            = ["memory"]

--- a/modules/autoscaling/main.tf
+++ b/modules/autoscaling/main.tf
@@ -34,4 +34,6 @@ module "ecs_cloudwatch_autoscaling_memory" {
   scale_down_cooldown   = 300
 
   tags = var.tags
+
+  depends_on = [module.ecs_cloudwatch_autoscaling_cpu]
 }


### PR DESCRIPTION
While working with a downstream consumer of this repository, I ran into this (abbreviated/obfuscated) error.

```
│ Error: creating Application AutoScaling Target (service/sr-fargate/sr-thing123456): operation error Application Auto Scaling: RegisterScalableTarget, https response error StatusCode: 400, RequestID: ------, ConcurrentUpdateException: You already have a pending update to an Auto Scaling resource.
│ 
│   with module...ecs_cloudwatch_autoscaling_cpu.aws_appautoscaling_target.default[0],
│   on .terraform/modules/...ecs_cloudwatch_autoscaling_cpu/main.tf line 15, in resource "aws_appautoscaling_target" "default":
│   15: resource "aws_appautoscaling_target" "default" {
│ 
```

Reading [some SO guidance on this error](https://stackoverflow.com/questions/59629796/terraform-concurrentupdateexception-you-already-have-a-pending-update-to-an-au) and tracing the error down to this repository led me to see if updating this dependency would fix the problem.

The [0.7.5 release notes](https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-autoscaling/releases/tag/0.7.5) for the cloudposse autoscaling module suggested that they might address the core issue.

I tried using some local paths and found that it did not, in fact, help, but it didn't hurt either! :) So I figured I'd upstream the dependency update while I was here.

What _does_ fix the error is to make the memory scaling target depend on the CPU scaling target.
Place that ultimately led me to this fix:
* https://stackoverflow.com/a/78577667/1524502
* https://keita.blog/2018/01/29/aws-application-auto-scaling-for-ecs-with-terraform/